### PR TITLE
Make username optional for OAUTHBEARER

### DIFF
--- a/oauthbearer_test.go
+++ b/oauthbearer_test.go
@@ -141,4 +141,28 @@ func TestOAuthBearerServerAndClient(t *testing.T) {
 			t.Fatal("Wrong scope:", authzErr.Scope)
 		}
 	})
+
+	authenticator = func(opts sasl.OAuthBearerOptions) *sasl.OAuthBearerError {
+		if opts.Username == "" && opts.Token == "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB" {
+			return nil
+		}
+		return &oauthErr
+	}
+	t.Run("valid token, no username", func(t *testing.T) {
+		s := sasl.NewOAuthBearerServer(authenticator)
+		c := sasl.NewOAuthBearerClient(&sasl.OAuthBearerOptions{
+			Token: "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB",
+		})
+		_, ir, err := c.Start()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, done, err := s.Next(ir)
+		if err != nil {
+			t.Fatal("Unexpected error")
+		}
+		if !done {
+			t.Fatal("Exchange is not complete")
+		}
+	})
 }


### PR DESCRIPTION
Per RFC 5801, the username is optional:

    gs2-authzid    = "a=" saslname
    gs2-header = [gs2-nonstd-flag ","] gs2-cb-flag "," [gs2-authzid] ","

This is useful when a client only has a token, and doesn't know the username.