### PR TITLE
chore: added xoauth2 support, as needed by Microsoft and Google servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Implemented mechanisms:
 * [LOGIN](https://tools.ietf.org/html/draft-murchison-sasl-login-00) (obsolete, use PLAIN instead)
 * [PLAIN](https://tools.ietf.org/html/rfc4616)
 * [OAUTHBEARER](https://tools.ietf.org/html/rfc7628)
+* [XOAUTH2](https://developers.google.com/gmail/imap/xoauth2-protocol)
 
 ## License
 

--- a/xoauth2.go
+++ b/xoauth2.go
@@ -1,0 +1,156 @@
+package sasl
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// The XOAUTH2 mechanism name.
+const XOAuth2 = "XOAUTH2"
+
+type XOAuth2Error struct {
+	Status  string `json:"status"`
+	Schemes string `json:"schemes"`
+	Scope   string `json:"scope"`
+}
+
+type XOAuth2Options struct {
+	Username string
+	Token    string
+}
+
+// Implements error
+func (err *XOAuth2Error) Error() string {
+	return fmt.Sprintf("XOAUTH2 authentication error (%v)", err.Status)
+}
+
+type xoauth2Client struct {
+	XOAuth2Options
+}
+
+func (a *xoauth2Client) Start() (mech string, ir []byte, err error) {
+	ir = []byte(`user=`)
+	ir = append(ir, a.Username...)
+	ir = append(ir, '\x01')
+	ir = append(ir, []byte(`auth=Bearer `)...)
+	ir = append(ir, a.Token...)
+	ir = append(ir, '\x01', '\x01')
+
+	return XOAuth2, ir, nil
+}
+
+func (a *xoauth2Client) Next(challenge []byte) ([]byte, error) {
+	authErr := &XOAuth2Error{}
+	if err := json.Unmarshal(challenge, authErr); err != nil {
+		return nil, err
+	} else {
+		return nil, authErr
+	}
+}
+
+// NewXOAuth2Client An implementation of the XOAUTH2 authentication mechanism, as
+// described in Google / Microsoft docs, example
+// https://developers.google.com/gmail/imap/xoauth2-protocol
+func NewXOAuth2Client(opt *XOAuth2Options) Client {
+	return &xoauth2Client{*opt}
+}
+
+type XOAuth2Authenticator func(opts XOAuth2Options) *XOAuth2Error
+
+type xoauth2Server struct {
+	done         bool
+	failErr      error
+	authenticate XOAuth2Authenticator
+}
+
+func (a *xoauth2Server) fail(descr string) ([]byte, bool, error) {
+	blob, err := json.Marshal(XOAuth2Error{
+		Status:  "invalid_request",
+		Schemes: "bearer",
+	})
+	if err != nil {
+		panic(err) // wtf
+	}
+	a.failErr = errors.New(descr)
+	return blob, false, nil
+}
+
+func (a *xoauth2Server) Next(response []byte) (challenge []byte, done bool, err error) {
+	if a.failErr != nil {
+		if len(response) != 1 && response[0] != 0x01 {
+			return nil, true, errors.New("unexpected response")
+		}
+		return nil, true, a.failErr
+	}
+
+	if a.done {
+		err = ErrUnexpectedClientResponse
+		return
+	}
+
+	// Generate empty challenge.
+	if response == nil {
+		return []byte{}, false, nil
+	}
+
+	a.done = true
+
+	// Cut user=username\x01auth=...\x01\x01
+	// into
+	// user=username
+	// auth=...
+	// <blank>
+	// <blank>
+	parts := bytes.Split(response, []byte{0x01})
+	if len(parts) != 4 {
+		return a.fail("Invalid response")
+	}
+	user := parts[0]
+	auth := parts[1]
+
+	opts := XOAuth2Options{}
+	if len(user) > 0 {
+		if !bytes.HasPrefix(user, []byte("user=")) {
+			return a.fail("Invalid response, missing 'user=' in gs2-authzid")
+		}
+		opts.Username = string(bytes.TrimPrefix(user, []byte("user=")))
+	}
+	if len(auth) > 0 {
+		pParts := bytes.SplitN(auth, []byte{'='}, 2)
+		if len(pParts) != 2 {
+			return a.fail("Invalid response, missing '='")
+		}
+
+		switch string(pParts[0]) {
+		case "auth":
+			const prefix = "bearer "
+			strValue := string(pParts[1])
+			// Token type is case-insensitive.
+			if !strings.HasPrefix(strings.ToLower(strValue), prefix) {
+				return a.fail("Unsupported token type")
+			}
+			opts.Token = strValue[len(prefix):]
+		default:
+			return a.fail("Invalid response, unknown parameter: " + string(pParts[0]))
+		}
+	}
+
+	authzErr := a.authenticate(opts)
+	if authzErr != nil {
+		blob, err := json.Marshal(authzErr)
+		if err != nil {
+			panic(err) // wtf
+		}
+		a.failErr = authzErr
+		return blob, false, nil
+	}
+
+	return nil, true, nil
+}
+
+func NewXOAuth2Server(auth XOAuth2Authenticator) Server {
+	return &xoauth2Server{authenticate: auth}
+}

--- a/xoauth2_test.go
+++ b/xoauth2_test.go
@@ -1,0 +1,125 @@
+package sasl_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/emersion/go-sasl"
+)
+
+func TestNewXOAuth2Client(t *testing.T) {
+	c := sasl.NewXOAuth2Client(&sasl.XOAuth2Options{
+		Username: "user@example.com",
+		Token:    "vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg==",
+	})
+	mech, ir, err := c.Start()
+	if err != nil {
+		t.Fatal("Error while starting client:", err)
+	}
+	if mech != "XOAUTH2" {
+		t.Error("Invalid mechanism name:", mech)
+	}
+
+	expected := []byte{117, 115, 101, 114, 61, 117, 115, 101, 114,
+		64, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111,
+		109, 1,
+		97, 117, 116, 104, 61, 66, 101, 97, 114, 101,
+		114, 32, 118, 70, 57, 100, 102, 116, 52, 113, 109,
+		84, 99, 50, 78, 118, 98, 51, 82, 108, 99, 107, 66,
+		104, 98, 72, 82, 104, 100, 109, 108, 122, 100, 71,
+		69, 117, 89, 50, 57, 116, 67, 103, 61, 61, 1, 1}
+	if bytes.Compare(ir, expected) != 0 {
+		t.Error("Invalid initial response:", ir)
+	}
+}
+
+func TestXOAuth2ServerAndClient(t *testing.T) {
+	oauthErr := sasl.XOAuth2Error{
+		Status:  "invalid_token",
+		Scope:   "email",
+		Schemes: "bearer",
+	}
+	authenticator := func(opts sasl.XOAuth2Options) *sasl.XOAuth2Error {
+		if opts.Username == "fxcp" && opts.Token == "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB" {
+			return nil
+		}
+		return &oauthErr
+	}
+
+	t.Run("valid token", func(t *testing.T) {
+		s := sasl.NewXOAuth2Server(authenticator)
+		c := sasl.NewXOAuth2Client(&sasl.XOAuth2Options{
+			Username: "fxcp",
+			Token:    "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB",
+		})
+		_, ir, err := c.Start()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, done, err := s.Next(ir)
+		if err != nil {
+			t.Fatal("Unexpected error")
+		}
+		if !done {
+			t.Fatal("Exchange is not complete")
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		s := sasl.NewXOAuth2Server(authenticator)
+		c := sasl.NewXOAuth2Client(&sasl.XOAuth2Options{
+			Username: "fxcp",
+			Token:    "adiffrentone",
+		})
+		_, ir, err := c.Start()
+		if err != nil {
+			t.Fatal(err)
+		}
+		val, done, err := s.Next(ir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if done {
+			t.Fatal("Exchange is marked complete")
+		}
+
+		_, err = c.Next(val)
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+		authzErr, ok := err.(*sasl.XOAuth2Error)
+		if !ok {
+			t.Fatal("Not XOAuth2Error")
+		}
+		if authzErr.Status != "invalid_token" {
+			t.Fatal("Wrong status:", authzErr.Status)
+		}
+		if authzErr.Scope != "email" {
+			t.Fatal("Wrong scope:", authzErr.Scope)
+		}
+	})
+
+	authenticator = func(opts sasl.XOAuth2Options) *sasl.XOAuth2Error {
+		if opts.Username == "" && opts.Token == "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB" {
+			return nil
+		}
+		return &oauthErr
+	}
+	t.Run("valid token, no username", func(t *testing.T) {
+		s := sasl.NewXOAuth2Server(authenticator)
+		c := sasl.NewXOAuth2Client(&sasl.XOAuth2Options{
+			Token: "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB",
+		})
+		_, ir, err := c.Start()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, done, err := s.Next(ir)
+		if err != nil {
+			t.Fatal("Unexpected error")
+		}
+		if !done {
+			t.Fatal("Exchange is not complete")
+		}
+	})
+}


### PR DESCRIPTION
One of our older services retrieves email from IMAP and doesn't support OAUTH2, so I used the libraries to create a proxy which does the auth part on behalf of the client. However, it seems that Google and Microsoft don't support OAUTHBEARER, but implement a slightly different standard XOAUTH2 (I couldn't find an RFC for this), but their docs are similar:

[MS](https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth#use-client-credentials-grant-flow-to-authenticate-imap-and-pop-connections)
[Google](https://developers.google.com/gmail/imap/xoauth2-protocol)

`xoauth2` is basically a copy of `oauthbearer` but the fields updated:

From
```
n,a=xxx,\X01(host=aaa\X01port=bbb)auth=Bearer yyy\X01\X01
```
To
```
user=xxx\X01auth=Bearer yyy\X01\X01
```

