### PR TITLE
Adding support for xoauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# IDE
+*.iml
+.idea/

--- a/xoauth2.go
+++ b/xoauth2.go
@@ -1,0 +1,48 @@
+package sasl
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// The XOAUTH2 mechanism name.
+const Xoauth2 = "XOAUTH2"
+
+// An XOAUTH2 error.
+type Xoauth2Error struct {
+	Status  string `json:"status"`
+	Schemes string `json:"schemes"`
+	Scope   string `json:"scope"`
+}
+
+// Implements error.
+func (err *Xoauth2Error) Error() string {
+	return fmt.Sprintf("XOAUTH2 authentication error (%v)", err.Status)
+}
+
+type xoauth2Client struct {
+	Username string
+	Token    string
+}
+
+func (a *xoauth2Client) Start() (mech string, ir []byte, err error) {
+	mech = Xoauth2
+	ir = []byte("user=" + a.Username + "\x01auth=Bearer " + a.Token + "\x01\x01")
+	return
+}
+
+func (a *xoauth2Client) Next(challenge []byte) ([]byte, error) {
+	// Server sent an error response
+	xoauth2Err := &Xoauth2Error{}
+	if err := json.Unmarshal(challenge, xoauth2Err); err != nil {
+		return nil, err
+	} else {
+		return nil, xoauth2Err
+	}
+}
+
+// An implementation of the XOAUTH2 authentication mechanism, as
+// described in https://developers.google.com/gmail/xoauth2_protocol.
+func NewXoauth2Client(username, token string) Client {
+	return &xoauth2Client{username, token}
+}

--- a/xoauth2_test.go
+++ b/xoauth2_test.go
@@ -1,0 +1,38 @@
+package sasl_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-sasl"
+)
+
+func TestNewXoauth2Client(t *testing.T) {
+	c := sasl.NewXoauth2Client("user@example.com", "vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg==")
+
+	mech, ir, err := c.Start()
+	if err != nil {
+		t.Fatal("Error while starting client:", err)
+	}
+	if mech != "XOAUTH2" {
+		t.Error("Invalid mechanism name:", mech)
+	}
+
+	expected := "user=user@example.com\u0001auth=Bearer vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg==\u0001\u0001"
+	if strings.Compare(string(ir), expected) != 0 {
+		t.Error("Invalid initial response:", string(ir))
+	}
+
+	challenge := []byte("eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIiwic2NvcGUiOiJleGFt" +
+		"cGxlX3Njb3BlIiwib3BlbmlkLWNvbmZpZ3VyYXRpb24iOiJodHRwczovL2V4YW1wbGUu" +
+		"Y29tLy53ZWxsLWtub3duL29wZW5pZC1jb25maWd1cmF0aW9uIn0=")
+
+	if _, err := c.Next(challenge); err == nil {
+		t.Fatal("Expected error from handling challenge")
+	}
+
+	if _, err := c.Next([]byte("")); err == nil {
+		t.Fatal("Expected error from handling challenge")
+	}
+
+}


### PR DESCRIPTION
Hi @emersion ,

Can I add some support for xoauth2? Both google and microsoft is requiring xoauth2 to connect to IMAP now.
Google: https://developers.google.com/gmail/imap/xoauth2-protocol
Microsoft: https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth

I tested my code using my outlook account. It is working fine.