### PR TITLE
Dont send an empty challenge when no initial response in anonymous authentication

### DIFF
--- a/anonymous.go
+++ b/anonymous.go
@@ -37,11 +37,6 @@ func (s *anonymousServer) Next(response []byte) (challenge []byte, done bool, er
 		return
 	}
 
-	// No initial response, send an empty challenge
-	if response == nil {
-		return []byte{}, false, nil
-	}
-
 	s.done = true
 
 	err = s.authenticate(string(response))


### PR DESCRIPTION
The trace information in anonymous authentication is optional, so I don't think the server should send an empty challenge back if it is not specified in optional initial response argument to the AUTH command in SMTP for instance.

This is related to https://github.com/emersion/go-smtp/issues/258